### PR TITLE
Fix: pass string to draft_joke (use joke.joke)

### DIFF
--- a/level2_multi_interaction/t2_iterative_refinement.py
+++ b/level2_multi_interaction/t2_iterative_refinement.py
@@ -58,7 +58,7 @@ class IterativeJokeGenerator(dspy.Module):
             feedback = self.refinement(joke_idea=joke_idea, joke=joke)
             print(f"Feedback:\n{feedback}")
 
-            draft_joke = joke
+            draft_joke = joke.joke
             feedback = feedback.feedback
 
 


### PR DESCRIPTION
Should be draft_joke = joke.joke. The current code is relying on DSPy’s automatic coercion, but that’s brittle and confusing. Explicitly unwrapping (.joke) makes the flow clearer and type-safe.